### PR TITLE
Resizing images to speed up training

### DIFF
--- a/chalk_talk_demo.ipynb
+++ b/chalk_talk_demo.ipynb
@@ -448,6 +448,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Configure docker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure docker is configured for local training "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "pushd utils\n",
+    "bash setup.sh\n",
+    "popd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Fit estimator locally"
    ]
   },

--- a/src/shirts/train.py
+++ b/src/shirts/train.py
@@ -41,15 +41,25 @@ class MetricsLogger(LearnerCallback):
 # The train method
 def _train(args):
     print(f'Called _train method with model arch: {args.model_arch}, batch size: {args.batch_size}, image size: {args.image_size}, epochs: {args.epochs}, workers: {args.workers}, learn rate: {args.lr}, valid pct: {args.valid_pct}')
+
+    print(f'Resizing images from: {args.data_dir}')
+    verify_images(args.data_dir+'/sport', max_size=int(300))
+    verify_images(args.data_dir+'/metal', max_size=int(300))
+
     print(f'Getting training data from dir: {args.data_dir}')
-    data = ImageDataBunch.from_folder(args.data_dir, train=".", valid_pct=args.valid_pct,
-        ds_tfms=get_transforms(), size=args.image_size, num_workers=args.workers, bs=args.batch_size).normalize(imagenet_stats)
+    data = (ImageItemList.from_folder(args.data_dir)
+            .random_split_by_pct(args.valid_pct)
+            .label_from_folder()
+            .transform(get_transforms(), size=args.image_size)
+            .databunch(bs=args.batch_size, num_workers=args.workers)
+            .normalize(imagenet_stats))
+
     print(f'Model architecture is {args.model_arch}')
     arch = getattr(models, args.model_arch)
     print("Creating pretrained conv net")
     learn = create_cnn(data, arch, metrics=accuracy, callback_fns=[MetricsLogger])
     print("Fit four cycles")
-    learn.fit_one_cycle(4)
+    learn.fit_one_cycle(4, 1e-2)
     print(f'Unfreeze and run {args.epochs} more cycles')
     learn.unfreeze()
     learn.fit_one_cycle(args.epochs, max_lr=slice(args.lr/10,args.lr))


### PR DESCRIPTION
Some of the images are really large or in png format.

verify_images just resizes them to 300px jpgs. Seems to speed up training by about 3x.